### PR TITLE
Fixed memory leak

### DIFF
--- a/src/pattern/51Degrees.c
+++ b/src/pattern/51Degrees.c
@@ -1164,6 +1164,9 @@ fiftyoneDegreesDataSetInitStatus fiftyoneDegreesInitWithPropertyArray(const char
 		return status;
 	}
 
+	// Close the file
+	fclose(inputFilePtr);
+
 	// Set the prefixed upper headers to NULL as they may not be
 	// needed. If they are initialised later then the memory can
 	// be freed when the data set is destroyed.

--- a/src/pattern/51Degrees.i
+++ b/src/pattern/51Degrees.i
@@ -96,6 +96,12 @@ Provider *provider;
 
 	provider = new Provider(filePath, propertyList, cacheSize, poolSize);
 }
+
+
+%mshutdown {
+
+	delete provider;
+}
 #endif
 
 class Match {

--- a/src/pattern/Provider.cpp
+++ b/src/pattern/Provider.cpp
@@ -134,6 +134,7 @@ Provider::~Provider() {
 	// Free the dataset if one was created.
 	if (dataSet != NULL) {
 		fiftyoneDegreesDataSetFree(dataSet);
+		delete[] dataSet;
 		dataSet = NULL;
 	}
 }

--- a/src/trie/51Degrees.c
+++ b/src/trie/51Degrees.c
@@ -1,4 +1,4 @@
-﻿#include <stdio.h>
+#include <stdio.h>
 #include <stdarg.h>
 #include <stdint.h>
 #include <stdlib.h>

--- a/src/trie/51Degrees.i
+++ b/src/trie/51Degrees.i
@@ -92,6 +92,10 @@ Provider *provider;
 
 	provider = new Provider(filePath, propertyList);
 }
+%mshutdown {
+
+	delete provider;
+}
 #endif
 
 class Match {


### PR DESCRIPTION
Memory leaks were noticed when running Pattern PHP module.

Changes:
- Added %mshutdown section in PHP module code generation
- Explicitly `delete[] dataSet` in Provider's destructor
- Close file descriptor after reading data