### PR TITLE
Add condition for Mac to compile success

### DIFF
--- a/node.js/fiftyonedegreescore/binding.gyp
+++ b/node.js/fiftyonedegreescore/binding.gyp
@@ -12,6 +12,13 @@
                 "src/pattern/51Degrees_node.cpp"
             ],
             "cflags_cc!": ["-fno-exceptions"],
+            "conditions": [
+                            ['OS=="mac"', {
+                                "xcode_settings": {
+                                "GCC_ENABLE_CPP_EXCEPTIONS": "YES"
+                                }
+                            }]
+                        ],
             "cflags": ["<!(node -e \"\
                 var v8Version = process.versions.v8;\
                 var string = '-DSWIG_V8_VERSION=0x';\
@@ -36,6 +43,13 @@
                 "src/trie/51Degrees_node.cpp"
             ],
             "cflags_cc!": ["-fno-exceptions"],
+            "conditions": [
+                            ['OS=="mac"', {
+                                "xcode_settings": {
+                                "GCC_ENABLE_CPP_EXCEPTIONS": "YES"
+                                }
+                            }]
+                        ],
             "cflags": ["<!(node -e \"\
                 var v8Version = process.versions.v8;\
                 var string = '-DSWIG_V8_VERSION=0x';\


### PR DESCRIPTION
I came across the build error when installing the new node.js modules. 

`> node-gyp configure && node-gyp build

gyp WARN download NVM_NODEJS_ORG_MIRROR is deprecated and will be removed in node-gyp v4, please use NODEJS_ORG_MIRROR
gyp WARN download NVM_NODEJS_ORG_MIRROR is deprecated and will be removed in node-gyp v4, please use NODEJS_ORG_MIRROR
gyp WARN download NVM_NODEJS_ORG_MIRROR is deprecated and will be removed in node-gyp v4, please use NODEJS_ORG_MIRROR
  CC(target) Release/obj.target/FiftyOneDegreesPatternV3/src/pattern/51Degrees.o
../src/pattern/51Degrees.c:1242:8: warning: 'const' type qualifier on return type has no effect [-Wignored-qualifiers]
static const int32_t getSignatureNodeOffsetsCount(const fiftyoneDegreesDataSet _dataSet, const byte *signature) {
       ^~~~~~
../src/pattern/51Degrees.c:1280:8: warning: 'const' type qualifier on return type has no effect [-Wignored-qualifiers]
static const int32_t getRankFromSignature(const fiftyoneDegreesDataSet *dataSet, const byte *signature) {
       ^~~~~~
2 warnings generated.
  CC(target) Release/obj.target/FiftyOneDegreesPatternV3/src/cityhash/city.o
  CXX(target) Release/obj.target/FiftyOneDegreesPatternV3/src/pattern/Provider.o
../src/pattern/Provider.cpp:198:3: warning: 'delete' applied to a pointer that was allocated with 'new[]'; did you mean 'delete[]'? [-Wmismatched-new-delete]
                delete properties;
                ^
                      []
../src/pattern/Provider.cpp:185:28: note: allocated with 'new[]' here
        const char *_properties = new const char_[propertiesArray.size()];
                                  ^
../src/pattern/Provider.cpp:239:3: error: cannot use 'throw' with exceptions disabled
                throw runtime_error("Insufficient memory allocated.");
                ^
../src/pattern/Provider.cpp:242:3: error: cannot use 'throw' with exceptions disabled
                throw runtime_error("The data was not in the correct format. Check "
                ^
../src/pattern/Provider.cpp:246:3: error: cannot use 'throw' with exceptions disabled
                throw runtime_error("The data is an unsupported version. Check you "
                ^
../src/pattern/Provider.cpp:253:3: error: cannot use 'throw' with exceptions disabled
                throw invalid_argument(message.str());
                ^
../src/pattern/Provider.cpp:256:3: error: cannot use 'throw' with exceptions disabled
                throw runtime_error("Null pointer to the existing dataset or memory"
                ^
../src/pattern/Provider.cpp:260:3: error: cannot use 'throw' with exceptions disabled
                throw runtime_error("Allocated continuous memory containing "
                ^
../src/pattern/Provider.cpp:267:3: error: cannot use 'throw' with exceptions disabled
                throw runtime_error("Could not create data set from file.");
                ^
../src/pattern/Provider.cpp:769:4: error: cannot use 'throw' with exceptions disabled
                        throw runtime_error(message.str());
                        ^
1 warning and 8 errors generated.
make: *_\* [Release/obj.target/FiftyOneDegreesPatternV3/src/pattern/Provider.o] Error 1
gyp ERR! build error 
gyp ERR! stack Error: `make` failed with exit code: 2
gyp ERR! stack     at ChildProcess.onExit (/Users/tkwong/.nvm/versions/node/v6.4.0/lib/node_modules/npm/node_modules/node-gyp/lib/build.js:276:23)
gyp ERR! stack     at emitTwo (events.js:106:13)
gyp ERR! stack     at ChildProcess.emit (events.js:191:7)
gyp ERR! stack     at Process.ChildProcess._handle.onexit (internal/child_process.js:204:12)
gyp ERR! System Darwin 15.6.0
gyp ERR! command "/Users/tkwong/.nvm/versions/node/v6.4.0/bin/node" "/Users/tkwong/.nvm/versions/node/v6.4.0/lib/node_modules/npm/node_modules/node-gyp/bin/node-gyp.js" "build"
gyp ERR! cwd /Users/tkwong/Sites/ukrainian_tracker/node_modules/fiftyonedegreescore
gyp ERR! node -v v6.4.0
gyp ERR! node-gyp -v v3.3.1
gyp ERR! not ok 
npm ERR! Darwin 15.6.0
npm ERR! argv "/Users/tkwong/.nvm/versions/node/v6.4.0/bin/node" "/Users/tkwong/.nvm/versions/node/v6.4.0/bin/npm" "install" "fiftyonedegreescore"
npm ERR! node v6.4.0
npm ERR! npm  v3.10.3
npm ERR! code ELIFECYCLE

npm ERR! fiftyonedegreescore@3.2.7 install: `node-gyp configure && node-gyp build`
npm ERR! Exit status 1
npm ERR! 
npm ERR! Failed at the fiftyonedegreescore@3.2.7 install script 'node-gyp configure && node-gyp build'.
npm ERR! Make sure you have the latest version of node.js and npm installed.
npm ERR! If you do, this is most likely a problem with the fiftyonedegreescore package,
npm ERR! not with npm itself.
npm ERR! Tell the author that this fails on your system:
npm ERR!     node-gyp configure && node-gyp build
npm ERR! You can get information on how to open an issue for this project with:
npm ERR!     npm bugs fiftyonedegreescore
npm ERR! Or if that isn't available, you can get their info via:
npm ERR!     npm owner ls fiftyonedegreescore
npm ERR! There is likely additional logging output above.

npm ERR! Please include the following file with any support request:
npm ERR!     /Users/tkwong/Sites/ukrainian_tracker/npm-debug.log`
