### PR TITLE
undefined reference to clock_gettime

### DIFF
--- a/php/pattern/config.m4
+++ b/php/pattern/config.m4
@@ -16,6 +16,8 @@ if test "$PHP_FIFTYONEDEGREESPATTERNV3" = "yes"; then
   AC_CONFIG_COMMANDS_PRE(cp src/pattern/FiftyOneDegreesPatternV3.php includes/)
 
   AC_DEFINE(HAVE_FIFTYONEDEGREESPATTERNV3, 1, [Whether you have 51Degrees Detector Enabled])
+  CFLAGS="$CFLAGS -lrt"
+  PHP_SUBST([CFLAGS])
   PHP_SUBST(FIFTYONEDEGREESPATTERNV3_LIBADD)
 
   PHP_NEW_EXTENSION(FiftyOneDegreesPatternV3, src/cityhash/city.c src/threading.c src/pattern/51Degrees.c src/pattern/51Degrees_PHP.cpp src/pattern/Provider.cpp src/pattern/Match.cpp src/pattern/Profiles.cpp, $ext_shared, ,,"yes")

--- a/php/trie/config.m4
+++ b/php/trie/config.m4
@@ -16,6 +16,8 @@ if test "$PHP_FIFTYONEDEGREESTRIEV3" = "yes"; then
   AC_CONFIG_COMMANDS_PRE(cp src/trie/FiftyOneDegreesTrieV3.php includes/)
 
   AC_DEFINE(HAVE_FIFTYONEDEGREESTRIEV3, 1, [Whether you have 51Degrees Detector Enabled])
+  CFLAGS="$CFLAGS -lrt"
+  PHP_SUBST([CFLAGS])
   PHP_SUBST(FIFTYONEDEGREESTRIEV3_LIBADD)
 
   PHP_NEW_EXTENSION(FiftyOneDegreesTrieV3, src/cityhash/city.c src/threading.c src/trie/51Degrees.c src/trie/51Degrees_PHP.cpp src/trie/Provider.cpp src/trie/Match.cpp, $ext_shared, ,,"yes")


### PR DESCRIPTION
After compiling php library and adding it to php.ini I get an "undefined reference to clock_gettime" error when run php in system console.
Module looks like working in browser, but at console I see that error corresponding to FIFTYONEDEGREESTRIEV3 module.
I have added -lrt option into config.m4 and now php library doesn't generate an error.
I'm on CentOS release 6.8
gcc (GCC) 4.4.7 20120313 (Red Hat 4.4.7-17)
autoconf (GNU Autoconf) 2.63
GNU Make 3.81