### PR TITLE
Python3 issues

### DIFF
--- a/python/core/fiftyone_degrees/mobile_detector/__init__.py
+++ b/python/core/fiftyone_degrees/mobile_detector/__init__.py
@@ -96,8 +96,8 @@ class _V3WrapperMatcher(_Matcher):
                     'exist or is not readable. Please, '
                     'check your settings.' % settings.V3_WRAPPER_DATABASE)
             else:
-		from FiftyOneDegrees import fiftyone_degrees_mobile_detector_v3_wrapper
-		self.provider = fiftyone_degrees_mobile_detector_v3_wrapper.Provider(settings.V3_WRAPPER_DATABASE, settings.PROPERTIES, int(settings.CACHE_SIZE), int(settings.POOL_SIZE))
+                from FiftyOneDegrees import fiftyone_degrees_mobile_detector_v3_wrapper
+                self.provider = fiftyone_degrees_mobile_detector_v3_wrapper.Provider(settings.V3_WRAPPER_DATABASE, settings.PROPERTIES, int(settings.CACHE_SIZE), int(settings.POOL_SIZE))
         else:
             raise Exception(
                 'Trie-based detection method depends on an external '
@@ -116,23 +116,23 @@ class _V3WrapperMatcher(_Matcher):
         # Pythonize result.
         result = Device(self.ID)
 
-	if returnedMatch:
-		result.set_property('Id', returnedMatch.getDeviceId())
-		result.set_property('MatchMethod', returnedMatch.getMethod())
-		result.set_property('Difference', returnedMatch.getDifference())
-		result.set_property('Rank', returnedMatch.getRank())
-		if settings.PROPERTIES == '':
-			for key in self.provider.getAvailableProperties():
-				value = returnedMatch.getValues(key)
-				if value:
-					result.set_property(key, ' '.join(value))
-				else:
-					result.set_property(key, 'N/A in Lite')
-		else:
-			for key in settings.PROPERTIES.split(','):
-				value = returnedMatch.getValues(key)
-				if value:
-					result.set_property(key, ' '.join(value))
+        if returnedMatch:
+                result.set_property('Id', returnedMatch.getDeviceId())
+                result.set_property('MatchMethod', returnedMatch.getMethod())
+                result.set_property('Difference', returnedMatch.getDifference())
+                result.set_property('Rank', returnedMatch.getRank())
+                if settings.PROPERTIES == '':
+                        for key in self.provider.getAvailableProperties():
+                                value = returnedMatch.getValues(key)
+                                if value:
+                                        result.set_property(key, ' '.join(value))
+                                else:
+                                        result.set_property(key, 'N/A in Lite')
+                else:
+                        for key in settings.PROPERTIES.split(','):
+                                value = returnedMatch.getValues(key)
+                                if value:
+                                        result.set_property(key, ' '.join(value))
 
         # Done!
         return result
@@ -154,8 +154,8 @@ class _V3TrieWrapperMatcher(_Matcher):
                     'exist or is not readable. Please, '
                     'check your settings.' % settings.V3_TRIE_WRAPPER_DATABASE)
             else:
-		from FiftyOneDegrees import fiftyone_degrees_mobile_detector_v3_trie_wrapper
-		self.provider = fiftyone_degrees_mobile_detector_v3_trie_wrapper.Provider(settings.V3_TRIE_WRAPPER_DATABASE, settings.PROPERTIES)
+                from FiftyOneDegrees import fiftyone_degrees_mobile_detector_v3_trie_wrapper
+                self.provider = fiftyone_degrees_mobile_detector_v3_trie_wrapper.Provider(settings.V3_TRIE_WRAPPER_DATABASE, settings.PROPERTIES)
         else:
             raise Exception(
                 'Trie-based detection method depends on an external '
@@ -174,20 +174,20 @@ class _V3TrieWrapperMatcher(_Matcher):
         # Pythonize result.
         result = Device(self.ID)
 
-	print settings.PROPERTIES
-	if returnedMatch:
-		if settings.PROPERTIES == '':
-			for key in self.provider.getAvailableProperties():
-				value = returnedMatch.getValues(key)
-				if value:
-					result.set_property(key, ' '.join(value))
-				else:
-					result.set_property(key, 'N/A in Lite')
-		else:
-			for key in settings.PROPERTIES.split(','):
-				value = returnedMatch.getValues(key)
-				if value:
-					result.set_property(key, ' '.join(value))
+        print settings.PROPERTIES
+        if returnedMatch:
+                if settings.PROPERTIES == '':
+                        for key in self.provider.getAvailableProperties():
+                                value = returnedMatch.getValues(key)
+                                if value:
+                                        result.set_property(key, ' '.join(value))
+                                else:
+                                        result.set_property(key, 'N/A in Lite')
+                else:
+                        for key in settings.PROPERTIES.split(','):
+                                value = returnedMatch.getValues(key)
+                                if value:
+                                        result.set_property(key, ' '.join(value))
 
         # Done!
         return result

--- a/python/core/fiftyone_degrees/mobile_detector/runner.py
+++ b/python/core/fiftyone_degrees/mobile_detector/runner.py
@@ -38,7 +38,7 @@ def update_premium_pattern_wrapper(args, help):
 
     if settings.LICENSE:
         # Build source URL.
-        url = 'https://51degrees.com/Products/Downloads/Premium.aspx?LicenseKeys=%s&Type=BinaryV3&Download=True' % (
+        url = 'https://51degrees.com/Products/Downloads/Premium.aspx?LicenseKeys=%s&Type=BinaryV32&Download=True' % (
             settings.LICENSE
         )
 
@@ -50,12 +50,11 @@ def update_premium_pattern_wrapper(args, help):
             try:
                 # Fetch URL (no verification of the server's certificate here).
                 uh = urllib2.urlopen(url, timeout=120)
-                meta = uh.info()
 
                 # Check server response.
-                if meta.getheader('Content-Disposition') is not None:
+                if uh.headers['Content-Disposition'] is not None:
                     # Download the package.
-                    file_size = int(meta.getheader('Content-Length'))
+                    file_size = int(uh.headers['Content-Length'])
                     sys.stdout.write('=> Downloading %s bytes... ' % file_size)
                     downloaded = 0
                     while True:


### PR DESCRIPTION
While trying to run this on Python 3, I found two compatibility issues that 2to3 (the converter from Python 2 to Python 3) did not fix. Also found a third side-issue.

Side-issue: update_premium_pattern_wrapper calls for download of version 3.1 data rather than version 3.2 data.

Compatibility issues:
1) The __init__.py file mixes tabs and four-spaces. Python 3 doesn't like that and emits a "`inconsistent use of tabs and spaces in indentation`" when you run 51degrees-mobile-detector. See, for example, http://stackoverflow.com/questions/5685406/inconsistent-use-of-tabs-and-spaces-in-indentation
2) The way update_premium_pattern_wrapper checks headers breaks in python 3 and emits a `'HTTPMessage' object has no attribute 'getheaders'`. Substituted a method ostensibly compatible with both Python 2 and Python 3. (Confirmed for Python 2.7) See http://stackoverflow.com/questions/12996274/get-file-size-from-content-length-value-from-a-file-in-python-3-2
2a) May want to consider using requests library but that doesn't come pre-installed with Python.  
 