### PR TITLE
Remove extra declaration of fiftyoneDegreesResultsetCache

### DIFF
--- a/src/pattern/51Degrees.h
+++ b/src/pattern/51Degrees.h
@@ -408,8 +408,6 @@ typedef struct fiftyoneDegrees_linked_signature_list_t {
 	fiftyoneDegreesLinkedSignatureListItem *current; /* Pointer to the current item in the list when navigating */
 } fiftyoneDegreesLinkedSignatureList;
 
-typedef struct fiftyoneDegrees_resultset_cache_t fiftyoneDegreesResultsetCache;
-
 #pragma pack(push, 1)
 typedef struct fiftyoneDegrees_resultset_t {
 	FIFTYONE_DEGREES_COMMON_SET_FIELDS


### PR DESCRIPTION
When I was trying to compile fifty-one Degrees software, I got this error:
```
src/pattern/51Degrees.h:444: error: redefinition of typedef 'fiftyoneDegreesResultsetCache'
src/pattern/51Degrees.h:411: note: previous declaration of 'fiftyoneDegreesResultsetCache' was here
```

Since fiftyoneDegreesResultsetCache wasn't being used between lines 411 and 444, I commented out the line and the compile worked. (I've also used the software with no visible issues.)

Further research in stackoverflow (http://stackoverflow.com/questions/7772500/keep-getting-the-errors-redefinition-of-typedef-mystruct-and-previous-decl) indicates removing typedef in line 411 would also work.

I don't know what info is relevant for you to figure out why it worked for you but not for me. Let me know and I'll get it for you.