### PR TITLE
Add godoc examples to the pattern go package

### DIFF
--- a/go/src/pattern/FiftyOneDegreesPatternV3_test.go
+++ b/go/src/pattern/FiftyOneDegreesPatternV3_test.go
@@ -122,6 +122,47 @@ func MatchAllUserAgents() int {
 }
 
 /*
+ * Examples
+ */
+
+func Example() {
+	var (
+		provider Provider
+		match    Match
+	)
+
+	provider = NewProvider("../../../data/51Degrees-LiteV3.2.dat")
+	match = provider.GetMatch("Mozilla/5.0 (Windows NT 6.3; WOW64; rv:41.0) Gecko/20100101 Firefox/41.0")
+
+	// release the match when the function returns
+	defer DeleteMatch(match)
+
+	fmt.Println("IsMobile:", match.GetValue("IsMobile"))
+}
+
+// Increase the maximum number of matches the provider will supply
+func Example_increaseMaxMatches() {
+	var (
+		dataFilePath = "../../../data/51Degrees-LiteV3.2.dat"
+		cacheSize    = 10000
+		poolSize     = 50
+
+		provider = NewProvider(
+			dataFilePath,
+			cacheSize,
+			poolSize,
+		)
+
+		match = provider.GetMatch("Mozilla/5.0 (Windows NT 6.3; WOW64; rv:41.0) Gecko/20100101 Firefox/41.0")
+	)
+
+	// release the match when the function returns
+	defer DeleteMatch(match)
+
+	fmt.Println("IsMobile:", match.GetValue("IsMobile"))
+}
+
+/*
  * Tests
  */
 


### PR DESCRIPTION
This change allows `godoc` to display code examples. I specifically wanted an example showing how to increase the match pool size.

To view the examples, start `godoc`

```
$ godoc -http ":6060"
```

Then navigate to the pattern package:

http://127.0.0.1:6060/pkg/github.com/51Degrees/Device-Detection/go/src/pattern/